### PR TITLE
Add static octet option, optimizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,16 @@ The `ip-classifier-generator` package allows for `identifying the class of an IP
     );
     /// 30.80.122.140
 
+     console.log(
+      icg.randomIPV4ByRange({                      # Generate Random IP with predefined octets
+        firstOctet: 40,
+        secondOctet: 10,
+        thirdOctet: { min: 100, max: 130 },
+        fourthOctet: { min: 140, max: 170 },
+      }),
+    );
+    /// 40.10.125.166
+
   ```
 
 ## Authors

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ip-classifier-generator",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ip-classifier-generator",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "license": "ISC",
       "devDependencies": {
         "@types/jest": "^29.2.5",

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -34,3 +34,17 @@ test('Random IP By Range', () => {
   expect(+icg.randomIPV4ByRange({ fourthOctet: { min: 20, max: 50 } }).split('.')[3]).toBeGreaterThanOrEqual(20);
   expect(+icg.randomIPV4ByRange({ fourthOctet: { min: 20, max: 50 } }).split('.')[3]).toBeLessThanOrEqual(50);
 });
+
+test('Random IP with static range', () => {
+  expect(+icg.randomIPV4ByRange({ firstOctet: 10 }).split('.')[0]).toBe(10);
+  expect(+icg.randomIPV4ByRange({ firstOctet: 30 }).split('.')[0]).toBe(30);
+
+  expect(+icg.randomIPV4ByRange({ secondOctet: 20 }).split('.')[1]).toBe(20);
+  expect(+icg.randomIPV4ByRange({ secondOctet: 40 }).split('.')[1]).toBe(40);
+
+  expect(+icg.randomIPV4ByRange({ thirdOctet: 30 }).split('.')[2]).toBe(30);
+  expect(+icg.randomIPV4ByRange({ thirdOctet: 50 }).split('.')[2]).toBe(50);
+
+  expect(+icg.randomIPV4ByRange({ fourthOctet: 40 }).split('.')[3]).toBe(40);
+  expect(+icg.randomIPV4ByRange({ fourthOctet: 60 }).split('.')[3]).toBe(60);
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,12 @@
 interface Options {
-  firstOctet?: { min: number; max: number };
-  secondOctet?: { min: number; max: number };
-  thirdOctet?: { min: number; max: number };
-  fourthOctet?: { min: number; max: number };
+  firstOctet?: OctetOption
+  secondOctet?: OctetOption
+  thirdOctet?: OctetOption
+  fourthOctet?: OctetOption
 }
+
+type Range = { min: number; max: number };
+type OctetOption = Range | number;
 
 function clamp(value: number, min: number, max: number): number {
   if (value >= min && value <= max) {
@@ -14,42 +17,46 @@ function clamp(value: number, min: number, max: number): number {
   return max;
 }
 
-function randomNatural(value: { min: any; max: any }): number {
+function randomNatural(value: Range): number {
   return Math.floor(Math.random() * (value.max - value.min) + value.min);
 }
 
-function genPart(options?: { min: any; max: any }, index?: number, ipClass?: string): number {
+function parseValidate(arg: string | number, fallback: number): number {
+  if (typeof arg === 'string') {
+    return parseInt(arg, 10);
+  }
+  if (isNaN(arg) || !isFinite(arg)) {
+    return fallback;
+  }
+  return arg;
+}
+
+function genPart(options?: OctetOption, index?: number, ipClass?: string): number {
   const MAX = 255;
-  let min: number = options?.min;
-  let max: number = options?.max;
-  if (typeof min === 'string') {
-    min = parseInt(min, 10);
+  if (typeof options === 'number') {
+    // return 255 if greater than 255, 0 if less than 0, else return options
+    return options >= MAX ? MAX :
+      options <= 0 ? 0 : options;
+  } else {
+    // revert to range if not number
+    options = options as Range;
   }
-
-  if (typeof max === 'string') {
-    max = parseInt(max, 10);
-  }
-
-  if (isNaN(min) || !isFinite(min)) {
-    min = 0;
-  }
-
-  if (isNaN(max) || !isFinite(max)) {
-    max = MAX;
-  }
-  if (ipClass && ipClass?.match(/^[A-Aa-a]+$/) && index === 0) {
+  let min: number = parseValidate(options?.min, 0)
+  let max: number = parseValidate(options?.max, MAX)
+  
+  if (ipClass && ipClass?.match(/^[Aa]+$/) && index === 0) {
     min = clamp(min, 0, 127);
     max = clamp(max, 0, 127);
-  } else if (ipClass && ipClass?.match(/^[B-Bb-b]+$/) && index === 0) {
+  } else if (ipClass && ipClass?.match(/^[Bb]+$/) && index === 0) {
     min = clamp(min, 128, 191);
     max = clamp(max, 128, 191);
-  } else if (ipClass && ipClass?.match(/^[C-Cc-c]+$/) && index === 0) {
+  } else if (ipClass && ipClass?.match(/^[Cc]+$/) && index === 0) {
     min = clamp(min, 192, 223);
     max = clamp(max, 192, 223);
-  } else if (ipClass && ipClass?.match(/^[D-Dd-d]+$/) && index === 0) {
+  } else if (ipClass && ipClass?.match(/^[Dd]+$/) && index === 0) {
     min = clamp(min, 224, 239);
     max = clamp(max, 224, 239);
-  } else if (ipClass && ipClass?.match(/^[E-Ee-e]+$/) && index === 0) {
+  } else if (ipClass && ipClass?.match(/^[Ee]+$/) && index === 0) {
     min = clamp(min, 240, 255);
     max = clamp(max, 240, 255);
   } else {


### PR DESCRIPTION
- reuse `Range` and `OctetOption` types
- added `parseValidate` helper to handle string type and isNaN range numbers
- Simplify regex matching for classes to not use range for single characters
- Update package-lock to match
- Add tests and examples for static octets